### PR TITLE
Add global config editor

### DIFF
--- a/lib/any_talker/global_config.ex
+++ b/lib/any_talker/global_config.ex
@@ -50,6 +50,6 @@ defmodule AnyTalker.GlobalConfig do
   defp changeset(config, attrs) do
     config
     |> cast(attrs, @fields)
-    |> validate_required([:ask_model, :ask_rate_limit, :ask_rate_limit_scale_ms])
+    |> validate_required(@fields)
   end
 end

--- a/lib/any_talker/global_config.ex
+++ b/lib/any_talker/global_config.ex
@@ -30,7 +30,7 @@ defmodule AnyTalker.GlobalConfig do
     Repo.get!(__MODULE__, 1)
   end
 
-  @spec update_config(t(), map()) :: {:ok, t()} | {:error, Changeset.t()}
+  @spec update_config(t(), map()) :: {:ok, t()} | {:error, Ecto.Changeset.t()}
   def update_config(config, attrs) do
     result =
       config
@@ -42,7 +42,7 @@ defmodule AnyTalker.GlobalConfig do
     result
   end
 
-  @spec change_config(t(), map()) :: Changeset.t()
+  @spec change_config(t(), map()) :: Ecto.Changeset.t()
   def change_config(config, attrs \\ %{}) do
     changeset(config, attrs)
   end

--- a/lib/any_talker/global_config.ex
+++ b/lib/any_talker/global_config.ex
@@ -3,6 +3,8 @@ defmodule AnyTalker.GlobalConfig do
   use Ecto.Schema
   use Nebulex.Caching
 
+  import Ecto.Changeset
+
   alias AnyTalker.Cache
   alias AnyTalker.Repo
 
@@ -19,11 +21,35 @@ defmodule AnyTalker.GlobalConfig do
 
   @spec get(term()) :: term()
   def get(key) when key in @fields do
-    Map.fetch!(get(), key)
+    Map.fetch!(get_config(), key)
   end
 
+  @spec get_config() :: t()
   @decorate cacheable(cache: Cache)
-  defp get do
+  def get_config do
     Repo.get!(__MODULE__, 1)
+  end
+
+  @spec update_config(t(), map()) :: {:ok, t()} | {:error, Changeset.t()}
+  def update_config(config, attrs) do
+    result =
+      config
+      |> changeset(attrs)
+      |> Repo.update()
+
+    if match?({:ok, _}, result), do: Cache.delete_all()
+
+    result
+  end
+
+  @spec change_config(t(), map()) :: Changeset.t()
+  def change_config(config, attrs \\ %{}) do
+    changeset(config, attrs)
+  end
+
+  defp changeset(config, attrs) do
+    config
+    |> cast(attrs, @fields)
+    |> validate_required([:ask_model, :ask_rate_limit, :ask_rate_limit_scale_ms])
   end
 end

--- a/lib/any_talker_web/components/telegram_components.ex
+++ b/lib/any_talker_web/components/telegram_components.ex
@@ -88,4 +88,34 @@ defmodule AnyTalkerWeb.TelegramComponents do
     </div>
     """
   end
+
+  attr :id, :any, default: nil
+  attr :name, :any
+  attr :label, :string, default: nil
+  attr :value, :any
+  attr :type, :string, default: "text"
+
+  attr :field, FormField
+
+  @spec tg_input(map()) :: Rendered.t()
+  def tg_input(%{field: %FormField{} = field} = assigns) do
+    assigns =
+      assigns
+      |> assign(field: nil, id: assigns.id || field.id)
+      |> assign_new(:name, fn -> field.name end)
+      |> assign_new(:value, fn -> field.value end)
+
+    ~H"""
+    <div class="px-3">
+      <label for={@id}>{@label}</label>
+      <input
+        type={@type}
+        id={@id}
+        name={@name}
+        value={Phoenix.HTML.Form.normalize_value(@type, @value)}
+        class="mx-[3px] mt-2 block w-full rounded-lg text-zinc-900 focus:ring-0 sm:text-sm sm:leading-6"
+      />
+    </div>
+    """
+  end
 end

--- a/lib/any_talker_web/components/telegram_components.ex
+++ b/lib/any_talker_web/components/telegram_components.ex
@@ -83,9 +83,8 @@ defmodule AnyTalkerWeb.TelegramComponents do
         id={@id}
         name={@name}
         class="min-h-[6rem] mx-[3px] mt-2 block w-full rounded-lg text-zinc-900 focus:ring-0 sm:text-sm sm:leading-6"
-      >
-        {Phoenix.HTML.Form.normalize_value("textarea", @value)}
-        </textarea>
+      >{Phoenix.HTML.Form.normalize_value("textarea", @value)}
+      </textarea>
     </div>
     """
   end

--- a/lib/any_talker_web/lives/webapp/global_config_live.ex
+++ b/lib/any_talker_web/lives/webapp/global_config_live.ex
@@ -4,7 +4,6 @@ defmodule AnyTalkerWeb.WebApp.GlobalConfigLive do
 
   import AnyTalkerWeb.TelegramComponents
 
-  alias AnyTalker.Accounts
   alias AnyTalker.GlobalConfig
 
   @impl Phoenix.LiveView
@@ -15,7 +14,7 @@ defmodule AnyTalkerWeb.WebApp.GlobalConfigLive do
       <h1 class="mt-[15px] text-center text-xl font-bold">Глобальные настройки</h1>
     </.section>
 
-    <.section :if={@user_owner?} class="mt-5">
+    <.section class="mt-5">
       <:header>Настройки</:header>
       <div class="px-2">
         <.form for={@form} phx-change="save">
@@ -30,13 +29,9 @@ defmodule AnyTalkerWeb.WebApp.GlobalConfigLive do
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
-    user_owner? = Accounts.owner?(socket.assigns.current_user)
     config = GlobalConfig.get_config()
 
-    {:ok,
-     socket
-     |> assign(user_owner?: user_owner?)
-     |> assign_config(config)}
+    {:ok, assign_config(socket, config)}
   end
 
   @impl Phoenix.LiveView
@@ -47,18 +42,13 @@ defmodule AnyTalkerWeb.WebApp.GlobalConfigLive do
   @impl Phoenix.LiveView
   def handle_event("save", %{"global_config" => attrs}, socket) do
     config = socket.assigns.global_config
-    user_owner? = socket.assigns.user_owner?
 
-    if user_owner? do
-      case GlobalConfig.update_config(config, attrs) do
-        {:ok, new_config} ->
-          {:noreply, assign_config(socket, new_config)}
+    case GlobalConfig.update_config(config, attrs) do
+      {:ok, new_config} ->
+        {:noreply, assign_config(socket, new_config)}
 
-        {:error, _changeset} ->
-          {:noreply, assign_config(socket, config)}
-      end
-    else
-      {:noreply, assign_config(socket, config)}
+      {:error, _changeset} ->
+        {:noreply, assign_config(socket, config)}
     end
   end
 

--- a/lib/any_talker_web/lives/webapp/global_config_live.ex
+++ b/lib/any_talker_web/lives/webapp/global_config_live.ex
@@ -16,13 +16,16 @@ defmodule AnyTalkerWeb.WebApp.GlobalConfigLive do
 
     <.section class="mt-5">
       <:header>Настройки</:header>
-      <div class="px-2">
-        <.form for={@form} phx-change="save">
+      <.form for={@form} phx-change="save">
+        <div class="space-y-3">
+          <.tg_input label="Модель /ask" field={@form[:ask_model]} />
+          <.tg_input type="number" label="Лимит запросов /ask" field={@form[:ask_rate_limit]} />
+          <.tg_input type="number" label="Период лимита /ask (мс)" field={@form[:ask_rate_limit_scale_ms]} />
           <div class="mt-2">
             <.textarea label="Промпт /ask" field={@form[:ask_prompt]} />
           </div>
-        </.form>
-      </div>
+        </div>
+      </.form>
     </.section>
     """
   end

--- a/lib/any_talker_web/lives/webapp/global_config_live.ex
+++ b/lib/any_talker_web/lives/webapp/global_config_live.ex
@@ -1,0 +1,73 @@
+defmodule AnyTalkerWeb.WebApp.GlobalConfigLive do
+  @moduledoc false
+  use AnyTalkerWeb, :live_view
+
+  import AnyTalkerWeb.TelegramComponents
+
+  alias AnyTalker.Accounts
+  alias AnyTalker.GlobalConfig
+
+  @impl Phoenix.LiveView
+  def render(assigns) do
+    ~H"""
+    <div id="back-init" phx-hook="TelegramBack" data-state="on"></div>
+    <.section class="pt-[30px] pb-[15px]">
+      <h1 class="mt-[15px] text-center text-xl font-bold">Глобальные настройки</h1>
+    </.section>
+
+    <.section :if={@user_owner?} class="mt-5">
+      <:header>Настройки</:header>
+      <div class="px-2">
+        <.form for={@form} phx-change="save">
+          <div class="mt-2">
+            <.textarea label="Промпт /ask" field={@form[:ask_prompt]} />
+          </div>
+        </.form>
+      </div>
+    </.section>
+    """
+  end
+
+  @impl Phoenix.LiveView
+  def mount(_params, _session, socket) do
+    user_owner? = Accounts.owner?(socket.assigns.current_user)
+    config = GlobalConfig.get_config()
+
+    {:ok,
+     socket
+     |> assign(user_owner?: user_owner?)
+     |> assign_config(config)}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("back", _params, socket) do
+    {:noreply, push_navigate(socket, to: ~p"/webapp")}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("save", %{"global_config" => attrs}, socket) do
+    config = socket.assigns.global_config
+    user_owner? = socket.assigns.user_owner?
+
+    if user_owner? do
+      case GlobalConfig.update_config(config, attrs) do
+        {:ok, new_config} ->
+          {:noreply, assign_config(socket, new_config)}
+
+        {:error, _changeset} ->
+          {:noreply, assign_config(socket, config)}
+      end
+    else
+      {:noreply, assign_config(socket, config)}
+    end
+  end
+
+  defp assign_config(socket, config) do
+    form =
+      config
+      |> GlobalConfig.change_config()
+      |> to_form()
+
+    assign(socket, form: form, global_config: config)
+  end
+end

--- a/lib/any_talker_web/lives/webapp/menu_live.ex
+++ b/lib/any_talker_web/lives/webapp/menu_live.ex
@@ -18,6 +18,20 @@ defmodule AnyTalkerWeb.WebApp.MenuLive do
       <p class="text-tg-hint mt-2.5 text-center text-sm">Циничны как никогда</p>
     </.section>
 
+    <.section :if={@user_owner?} class="mt-5">
+      <:header>Настройки</:header>
+      <ul>
+        <li>
+          <.link
+            navigate={~p"/webapp/global"}
+            class="border-tg-section-separator hover-effect h-[42px] flex items-center rounded-lg border-b-2 pl-5 last:border-b-0"
+          >
+            <span class="text-[15px] py-2.5">Глобальный конфиг</span>
+          </.link>
+        </li>
+      </ul>
+    </.section>
+
     <.section class="mt-5">
       <:header>Чаты</:header>
       <p :if={@chats == []} class="text-[15px] text-tg-hint mt-2.5 text-center">Как одинокий зритель в пустом зале</p>
@@ -28,20 +42,6 @@ defmodule AnyTalkerWeb.WebApp.MenuLive do
             class="border-tg-section-separator hover-effect h-[42px] flex items-center rounded-lg border-b-2 pl-5 last:border-b-0"
           >
             <span class="text-[15px] py-2.5">{chat.title}</span>
-          </.link>
-        </li>
-      </ul>
-    </.section>
-
-    <.section :if={@user_owner?} class="mt-5">
-      <:header>Настройки</:header>
-      <ul>
-        <li>
-          <.link
-            navigate={~p"/webapp/global"}
-            class="border-tg-section-separator hover-effect h-[42px] flex items-center rounded-lg border-b-2 pl-5 last:border-b-0"
-          >
-            <span class="text-[15px] py-2.5">Глобальный конфиг</span>
           </.link>
         </li>
       </ul>

--- a/lib/any_talker_web/lives/webapp/menu_live.ex
+++ b/lib/any_talker_web/lives/webapp/menu_live.ex
@@ -32,12 +32,27 @@ defmodule AnyTalkerWeb.WebApp.MenuLive do
         </li>
       </ul>
     </.section>
+
+    <.section :if={@user_owner?} class="mt-5">
+      <:header>Настройки</:header>
+      <ul>
+        <li>
+          <.link
+            navigate={~p"/webapp/global"}
+            class="border-tg-section-separator hover-effect h-[42px] flex items-center rounded-lg border-b-2 pl-5 last:border-b-0"
+          >
+            <span class="text-[15px] py-2.5">Глобальный конфиг</span>
+          </.link>
+        </li>
+      </ul>
+    </.section>
     """
   end
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
     chats = Accounts.list_user_chats(socket.assigns.current_user.id)
-    {:ok, assign(socket, chats: chats)}
+    user_owner? = Accounts.owner?(socket.assigns.current_user)
+    {:ok, assign(socket, chats: chats, user_owner?: user_owner?)}
   end
 end

--- a/lib/any_talker_web/plugs/admin_plug.ex
+++ b/lib/any_talker_web/plugs/admin_plug.ex
@@ -1,0 +1,18 @@
+defmodule AnyTalkerWeb.AdminPlug do
+  @moduledoc false
+  use AnyTalkerWeb, :verified_routes
+
+  alias AnyTalker.Accounts
+  alias Phoenix.LiveView.Socket
+
+  @spec on_mount(atom(), Phoenix.LiveView.unsigned_params(), map(), Socket.t()) ::
+          {:cont, Socket.t()} | {:halt, Socket.t()}
+  def on_mount(:ensure_owner, _params, _session, socket) do
+    if Accounts.owner?(socket.assigns.current_user) do
+      {:cont, socket}
+    else
+      socket = Phoenix.LiveView.redirect(socket, to: ~p"/webapp")
+      {:halt, socket}
+    end
+  end
+end

--- a/lib/any_talker_web/router.ex
+++ b/lib/any_talker_web/router.ex
@@ -59,6 +59,7 @@ defmodule AnyTalkerWeb.Router do
       on_mount: [{AnyTalkerWeb.AuthPlug, :ensure_authenticated}] do
       live "/", MenuLive
       live "/c/:chat_id", ChatLive
+      live "/global", GlobalConfigLive
     end
   end
 

--- a/lib/any_talker_web/router.ex
+++ b/lib/any_talker_web/router.ex
@@ -59,6 +59,13 @@ defmodule AnyTalkerWeb.Router do
       on_mount: [{AnyTalkerWeb.AuthPlug, :ensure_authenticated}] do
       live "/", MenuLive
       live "/c/:chat_id", ChatLive
+    end
+
+    live_session :require_admin_user,
+      on_mount: [
+        {AnyTalkerWeb.AuthPlug, :ensure_authenticated},
+        {AnyTalkerWeb.AdminPlug, :ensure_owner}
+      ] do
       live "/global", GlobalConfigLive
     end
   end


### PR DESCRIPTION
## Summary
- add Ecto changeset functions for `GlobalConfig`
- create `GlobalConfigLive` to edit global prompt
- link global config page from menu
- wire up route for new page

## Testing
- `mix format`
- `mix ci`

------
https://chatgpt.com/codex/tasks/task_e_6842bc2af18483288504edb2f540b3d3