### PR TITLE
cleanup global live

### DIFF
--- a/lib/any_talker_web/lives/webapp/global_config_live.ex
+++ b/lib/any_talker_web/lives/webapp/global_config_live.ex
@@ -4,7 +4,6 @@ defmodule AnyTalkerWeb.WebApp.GlobalConfigLive do
 
   import AnyTalkerWeb.TelegramComponents
 
-  alias AnyTalker.Accounts
   alias AnyTalker.GlobalConfig
 
   @impl Phoenix.LiveView
@@ -15,7 +14,7 @@ defmodule AnyTalkerWeb.WebApp.GlobalConfigLive do
       <h1 class="mt-[15px] text-center text-xl font-bold">Глобальные настройки</h1>
     </.section>
 
-    <.section :if={@user_owner?} class="mt-5">
+    <.section class="mt-5">
       <:header>Настройки</:header>
       <div class="px-2">
         <.form for={@form} phx-change="save">
@@ -30,13 +29,9 @@ defmodule AnyTalkerWeb.WebApp.GlobalConfigLive do
 
   @impl Phoenix.LiveView
   def mount(_params, _session, socket) do
-    user_owner? = Accounts.owner?(socket.assigns.current_user)
     config = GlobalConfig.get_config()
 
-    {:ok,
-     socket
-     |> assign(user_owner?: user_owner?)
-     |> assign_config(config)}
+    {:ok, assign_config(socket, config)}
   end
 
   @impl Phoenix.LiveView
@@ -47,18 +42,13 @@ defmodule AnyTalkerWeb.WebApp.GlobalConfigLive do
   @impl Phoenix.LiveView
   def handle_event("save", %{"global_config" => attrs}, socket) do
     config = socket.assigns.global_config
-    user_owner? = socket.assigns.user_owner?
 
-    if user_owner? do
-      case GlobalConfig.update_config(config, attrs) do
-        {:ok, new_config} ->
-          {:noreply, assign_config(socket, new_config)}
+    case GlobalConfig.update_config(config, attrs) do
+      {:ok, new_config} ->
+        {:noreply, assign_config(socket, new_config)}
 
-        {:error, _changeset} ->
-          {:noreply, assign_config(socket, config)}
-      end
-    else
-      {:noreply, assign_config(socket, config)}
+      {:error, _changeset} ->
+        {:noreply, assign_config(socket, config)}
     end
   end
 

--- a/lib/any_talker_web/plugs/admin_plug.ex
+++ b/lib/any_talker_web/plugs/admin_plug.ex
@@ -1,0 +1,18 @@
+defmodule AnyTalkerWeb.AdminPlug do
+  @moduledoc false
+  use AnyTalkerWeb, :verified_routes
+
+  alias AnyTalker.Accounts
+  alias Phoenix.LiveView.Socket
+
+  @spec on_mount(atom(), Phoenix.LiveView.unsigned_params(), map(), Socket.t()) ::
+          {:cont, Socket.t()} | {:halt, Socket.t()}
+  def on_mount(:ensure_owner, _params, _session, socket) do
+    if Accounts.owner?(socket.assigns.current_user) do
+      {:cont, socket}
+    else
+      socket = Phoenix.LiveView.redirect(socket, to: ~p"/webapp")
+      {:halt, socket}
+    end
+  end
+end

--- a/lib/any_talker_web/router.ex
+++ b/lib/any_talker_web/router.ex
@@ -59,6 +59,13 @@ defmodule AnyTalkerWeb.Router do
       on_mount: [{AnyTalkerWeb.AuthPlug, :ensure_authenticated}] do
       live "/", MenuLive
       live "/c/:chat_id", ChatLive
+    end
+
+    live_session :require_admin_user,
+      on_mount: [
+        {AnyTalkerWeb.AuthPlug, :ensure_authenticated},
+        {AnyTalkerWeb.AdminPlug, :ensure_owner}
+      ] do
       live "/global", GlobalConfigLive
     end
   end


### PR DESCRIPTION
## Summary
- remove redundant admin check on GlobalConfigLive
- rely on router's admin session to gate access

## Testing
- `mix ci`

------
https://chatgpt.com/codex/tasks/task_e_684bfe12f6888328897cff4816e58787