### PR TITLE
Add global config inputs

### DIFF
--- a/lib/any_talker_web/components/telegram_components.ex
+++ b/lib/any_talker_web/components/telegram_components.ex
@@ -88,4 +88,34 @@ defmodule AnyTalkerWeb.TelegramComponents do
     </div>
     """
   end
+
+  attr :id, :any, default: nil
+  attr :name, :any
+  attr :label, :string, default: nil
+  attr :value, :any
+  attr :type, :string, default: "text"
+
+  attr :field, FormField
+
+  @spec tg_input(map()) :: Rendered.t()
+  def tg_input(%{field: %FormField{} = field} = assigns) do
+    assigns =
+      assigns
+      |> assign(field: nil, id: assigns.id || field.id)
+      |> assign_new(:name, fn -> field.name end)
+      |> assign_new(:value, fn -> field.value end)
+
+    ~H"""
+    <div class="px-3">
+      <label for={@id}>{@label}</label>
+      <input
+        type={@type}
+        id={@id}
+        name={@name}
+        value={Phoenix.HTML.Form.normalize_value(@type, @value)}
+        class="mx-[3px] mt-2 block w-full rounded-lg text-zinc-900 focus:ring-0 sm:text-sm sm:leading-6"
+      />
+    </div>
+    """
+  end
 end

--- a/lib/any_talker_web/lives/webapp/global_config_live.ex
+++ b/lib/any_talker_web/lives/webapp/global_config_live.ex
@@ -16,16 +16,16 @@ defmodule AnyTalkerWeb.WebApp.GlobalConfigLive do
 
     <.section class="mt-5">
       <:header>Настройки</:header>
-      <div class="space-y-2 px-2">
-        <.form for={@form} phx-change="save">
+      <.form for={@form} phx-change="save">
+        <div class="space-y-3">
           <.tg_input label="Модель /ask" field={@form[:ask_model]} />
           <.tg_input type="number" label="Лимит запросов /ask" field={@form[:ask_rate_limit]} />
           <.tg_input type="number" label="Период лимита /ask (мс)" field={@form[:ask_rate_limit_scale_ms]} />
           <div class="mt-2">
             <.textarea label="Промпт /ask" field={@form[:ask_prompt]} />
           </div>
-        </.form>
-      </div>
+        </div>
+      </.form>
     </.section>
     """
   end

--- a/lib/any_talker_web/lives/webapp/global_config_live.ex
+++ b/lib/any_talker_web/lives/webapp/global_config_live.ex
@@ -16,8 +16,11 @@ defmodule AnyTalkerWeb.WebApp.GlobalConfigLive do
 
     <.section class="mt-5">
       <:header>Настройки</:header>
-      <div class="px-2">
+      <div class="space-y-2 px-2">
         <.form for={@form} phx-change="save">
+          <.tg_input label="Модель /ask" field={@form[:ask_model]} />
+          <.tg_input type="number" label="Лимит запросов /ask" field={@form[:ask_rate_limit]} />
+          <.tg_input type="number" label="Период лимита /ask (мс)" field={@form[:ask_rate_limit_scale_ms]} />
           <div class="mt-2">
             <.textarea label="Промпт /ask" field={@form[:ask_prompt]} />
           </div>


### PR DESCRIPTION
## Summary
- extend TelegramComponents with `tg_input`
- list all global config options on the edit page

## Testing
- `mix ci`

------
https://chatgpt.com/codex/tasks/task_e_684c117eda408328b76741e96bd27107