### PR TITLE
feat/user-custom-name

### DIFF
--- a/lib/any_talker/accounts.ex
+++ b/lib/any_talker/accounts.ex
@@ -8,6 +8,11 @@ defmodule AnyTalker.Accounts do
   alias AnyTalker.Repo
   alias AnyTalker.Settings.ChatConfig
 
+  @spec get_user(integer()) :: User.t() | nil
+  def get_user(id) do
+    Repo.get(User, id)
+  end
+
   @spec upsert_user(map(), [atom()]) :: {:ok, User.t()} | {:error, Ecto.Changeset.t()}
   def upsert_user(attrs, keys) do
     %User{}
@@ -20,6 +25,11 @@ defmodule AnyTalker.Accounts do
     user
     |> User.changeset(attrs)
     |> Repo.update()
+  end
+
+  @spec change_user(User.t(), map()) :: Ecto.Changeset.t()
+  def change_user(user, attrs \\ %{}) do
+    User.changeset(user, attrs)
   end
 
   @spec create_token(User.t()) :: String.t()
@@ -64,16 +74,6 @@ defmodule AnyTalker.Accounts do
   @spec owner?(User.t()) :: boolean()
   def owner?(%User{id: user_id}) do
     Application.get_env(:any_talker, :owner_id) == user_id
-  end
-
-  @spec get_user(integer()) :: User.t() | nil
-  def get_user(id) do
-    Repo.get(User, id)
-  end
-
-  @spec change_user(User.t(), map()) :: Ecto.Changeset.t()
-  def change_user(user, attrs \\ %{}) do
-    User.changeset(user, attrs)
   end
 
   @spec display_name(User.t() | nil) :: String.t() | nil

--- a/lib/any_talker/accounts.ex
+++ b/lib/any_talker/accounts.ex
@@ -65,4 +65,21 @@ defmodule AnyTalker.Accounts do
   def owner?(%User{id: user_id}) do
     Application.get_env(:any_talker, :owner_id) == user_id
   end
+
+  @spec get_user(integer()) :: User.t() | nil
+  def get_user(id) do
+    Repo.get(User, id)
+  end
+
+  @spec change_user(User.t(), map()) :: Ecto.Changeset.t()
+  def change_user(user, attrs \\ %{}) do
+    User.changeset(user, attrs)
+  end
+
+  @spec display_name(User.t() | nil) :: String.t() | nil
+  def display_name(nil), do: nil
+
+  def display_name(%User{} = user) do
+    user.custom_name || user.first_name
+  end
 end

--- a/lib/any_talker/accounts/user.ex
+++ b/lib/any_talker/accounts/user.ex
@@ -9,6 +9,7 @@ defmodule AnyTalker.Accounts.User do
   schema "users" do
     field :username, :string
     field :allows_write_to_pm, :boolean, default: false
+    field :custom_name, :string
     field :first_name, :string
     field :last_name, :string
     field :photo_url, :string
@@ -20,7 +21,7 @@ defmodule AnyTalker.Accounts.User do
   @spec changeset(t(), map()) :: Ecto.Changeset.t()
   def changeset(user, attrs) do
     user
-    |> cast(attrs, [:id, :allows_write_to_pm, :first_name, :last_name, :photo_url, :username])
+    |> cast(attrs, [:id, :allows_write_to_pm, :first_name, :last_name, :photo_url, :username, :custom_name])
     |> validate_required([:first_name, :username])
   end
 end

--- a/lib/any_talker_web/lives/webapp/chat_live.ex
+++ b/lib/any_talker_web/lives/webapp/chat_live.ex
@@ -100,7 +100,7 @@ defmodule AnyTalkerWeb.WebApp.ChatLive do
   end
 
   defp username(nil), do: "Неизвестный пользователь"
-  defp username(user), do: user.first_name || user.username
+  defp username(user), do: Accounts.display_name(user) || user.username
 
   defp message_word(count), do: pluralize(count, "сообщение", "сообщения", "сообщений")
 end

--- a/lib/any_talker_web/lives/webapp/menu_live.ex
+++ b/lib/any_talker_web/lives/webapp/menu_live.ex
@@ -15,8 +15,22 @@ defmodule AnyTalkerWeb.WebApp.MenuLive do
       <div class="flex justify-center">
         <img src={@current_user.photo_url} class="rounded-full" width="90" height="90" alt="User photo" />
       </div>
-      <h1 class="mt-[15px] text-center text-xl font-bold">Добро пожаловать, {@current_user.first_name}!</h1>
+      <h1 class="mt-[15px] text-center text-xl font-bold">Добро пожаловать, {Accounts.display_name(@current_user)}!</h1>
       <p class="text-tg-hint mt-2.5 text-center text-sm">Циничны как никогда</p>
+    </.section>
+
+    <.section class="mt-5">
+      <:header>Аккаунт</:header>
+      <ul>
+        <li>
+          <.link
+            navigate={~p"/webapp/profile"}
+            class="border-tg-section-separator hover-effect h-[42px] flex items-center rounded-lg border-b-2 pl-5 last:border-b-0"
+          >
+            <span class="text-[15px] py-2.5">Настройки</span>
+          </.link>
+        </li>
+      </ul>
     </.section>
 
     <.section :if={@user_owner?} class="mt-5">

--- a/lib/any_talker_web/lives/webapp/menu_live.ex
+++ b/lib/any_talker_web/lives/webapp/menu_live.ex
@@ -19,20 +19,6 @@ defmodule AnyTalkerWeb.WebApp.MenuLive do
       <p class="text-tg-hint mt-2.5 text-center text-sm">Циничны как никогда</p>
     </.section>
 
-    <.section class="mt-5">
-      <:header>Аккаунт</:header>
-      <ul>
-        <li>
-          <.link
-            navigate={~p"/webapp/profile"}
-            class="border-tg-section-separator hover-effect h-[42px] flex items-center rounded-lg border-b-2 pl-5 last:border-b-0"
-          >
-            <span class="text-[15px] py-2.5">Настройки</span>
-          </.link>
-        </li>
-      </ul>
-    </.section>
-
     <.section :if={@user_owner?} class="mt-5">
       <:header>Админка</:header>
       <ul>
@@ -46,6 +32,20 @@ defmodule AnyTalkerWeb.WebApp.MenuLive do
         </li>
       </ul>
       <p class="text-tg-hint mt-2 text-center text-xs">Версия {BuildInfo.git_short_hash()}</p>
+    </.section>
+
+    <.section class="mt-5">
+      <:header>Аккаунт</:header>
+      <ul>
+        <li>
+          <.link
+            navigate={~p"/webapp/profile"}
+            class="border-tg-section-separator hover-effect h-[42px] flex items-center rounded-lg border-b-2 pl-5 last:border-b-0"
+          >
+            <span class="text-[15px] py-2.5">Настройки</span>
+          </.link>
+        </li>
+      </ul>
     </.section>
 
     <.section class="mt-5">

--- a/lib/any_talker_web/lives/webapp/profile_live.ex
+++ b/lib/any_talker_web/lives/webapp/profile_live.ex
@@ -1,0 +1,59 @@
+defmodule AnyTalkerWeb.WebApp.ProfileLive do
+  @moduledoc false
+  use AnyTalkerWeb, :live_view
+
+  import AnyTalkerWeb.TelegramComponents
+
+  alias AnyTalker.Accounts
+
+  @impl Phoenix.LiveView
+  def render(assigns) do
+    ~H"""
+    <div id="back-init" phx-hook="TelegramBack" data-state="on"></div>
+    <.section class="pt-[30px] pb-[15px]">
+      <h1 class="mt-[15px] text-center text-xl font-bold">Настройки профиля</h1>
+    </.section>
+
+    <.section class="mt-5">
+      <:header>Профиль</:header>
+      <.form for={@form} phx-change="save">
+        <div class="space-y-3">
+          <.tg_input label="Ник" field={@form[:custom_name]} />
+        </div>
+      </.form>
+    </.section>
+    """
+  end
+
+  @impl Phoenix.LiveView
+  def mount(_params, _session, socket) do
+    {:ok, assign_form(socket)}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("back", _params, socket) do
+    {:noreply, push_navigate(socket, to: ~p"/webapp")}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("save", %{"user" => attrs}, socket) do
+    user = socket.assigns.current_user
+
+    case Accounts.update_user(user, attrs) do
+      {:ok, new_user} ->
+        {:noreply, assign_form(assign(socket, current_user: new_user))}
+
+      {:error, _changeset} ->
+        {:noreply, assign_form(socket)}
+    end
+  end
+
+  defp assign_form(socket) do
+    form =
+      socket.assigns.current_user
+      |> Accounts.change_user()
+      |> to_form()
+
+    assign(socket, form: form)
+  end
+end

--- a/lib/any_talker_web/router.ex
+++ b/lib/any_talker_web/router.ex
@@ -58,6 +58,7 @@ defmodule AnyTalkerWeb.Router do
     live_session :require_authenticated_user,
       on_mount: [{AnyTalkerWeb.AuthPlug, :ensure_authenticated}] do
       live "/", MenuLive
+      live "/profile", ProfileLive
       live "/c/:chat_id", ChatLive
     end
 

--- a/priv/repo/migrations/20250613194326_add_custom_name_to_users.exs
+++ b/priv/repo/migrations/20250613194326_add_custom_name_to_users.exs
@@ -1,0 +1,9 @@
+defmodule AnyTalker.Repo.Migrations.AddCustomNameToUsers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :custom_name, :string
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- allow adding custom_name to users
- show custom_name where user names are rendered
- add a profile page to update custom_name

## Testing
- `mix ci`


------
https://chatgpt.com/codex/tasks/task_e_684c7e62bb9c8328b6835705f3566420