### PR TITLE
feat/settings: chat config overrides global

### DIFF
--- a/lib/any_talker/settings.ex
+++ b/lib/any_talker/settings.ex
@@ -1,5 +1,6 @@
 defmodule AnyTalker.Settings do
   @moduledoc false
+  alias AnyTalker.GlobalConfig
   alias AnyTalker.Repo
   alias AnyTalker.Settings.ChatConfig
 
@@ -26,5 +27,24 @@ defmodule AnyTalker.Settings do
   @spec change_chat_config(ChatConfig.t(), map()) :: Ecto.Changeset.t()
   def change_chat_config(chat_config, attrs \\ %{}) do
     ChatConfig.changeset(chat_config, attrs)
+  end
+
+  @spec get_full_chat_config(integer() | nil) :: ChatConfig.t()
+  def get_full_chat_config(nil), do: merge_configs(%ChatConfig{}, GlobalConfig.get_config())
+
+  def get_full_chat_config(id) do
+    id
+    |> get_chat_config()
+    |> merge_configs(GlobalConfig.get_config())
+  end
+
+  defp merge_configs(chat, global) do
+    %{
+      chat
+      | ask_model: chat.ask_model || global.ask_model,
+        ask_rate_limit: chat.ask_rate_limit || global.ask_rate_limit,
+        ask_rate_limit_scale_ms: chat.ask_rate_limit_scale_ms || global.ask_rate_limit_scale_ms,
+        ask_prompt: chat.ask_prompt || global.ask_prompt
+    }
   end
 end

--- a/lib/any_talker/settings/chat_config.ex
+++ b/lib/any_talker/settings/chat_config.ex
@@ -11,6 +11,9 @@ defmodule AnyTalker.Settings.ChatConfig do
     field :antispam, :boolean, default: false
     field :ask_command, :boolean, default: false
     field :ask_prompt, :string
+    field :ask_model, :string
+    field :ask_rate_limit, :integer
+    field :ask_rate_limit_scale_ms, :integer
 
     timestamps(type: :utc_datetime)
   end
@@ -18,7 +21,14 @@ defmodule AnyTalker.Settings.ChatConfig do
   @spec changeset(t(), map()) :: Ecto.Changeset.t()
   def changeset(chat_config, attrs) do
     chat_config
-    |> cast(attrs, [:antispam, :ask_command, :ask_prompt])
+    |> cast(attrs, [
+      :antispam,
+      :ask_command,
+      :ask_prompt,
+      :ask_model,
+      :ask_rate_limit,
+      :ask_rate_limit_scale_ms
+    ])
     |> validate_required([:antispam, :ask_command])
   end
 end

--- a/lib/any_talker_web/lives/webapp/chat_live.ex
+++ b/lib/any_talker_web/lives/webapp/chat_live.ex
@@ -44,6 +44,9 @@ defmodule AnyTalkerWeb.WebApp.ChatLive do
           <.form for={@form} phx-change="save">
             <.switch label="Антиспам" field={@form[:antispam]} />
             <.switch label="Команда /ask" field={@form[:ask_command]} />
+            <.tg_input label="Модель /ask" field={@form[:ask_model]} />
+            <.tg_input type="number" label="Лимит запросов /ask" field={@form[:ask_rate_limit]} />
+            <.tg_input type="number" label="Период лимита /ask (мс)" field={@form[:ask_rate_limit_scale_ms]} />
             <div class="mt-2">
               <.textarea label="Промпт /ask" field={@form[:ask_prompt]} />
             </div>

--- a/priv/repo/migrations/20250614000000_add_ai_fields_to_chat_config.exs
+++ b/priv/repo/migrations/20250614000000_add_ai_fields_to_chat_config.exs
@@ -1,0 +1,11 @@
+defmodule AnyTalker.Repo.Migrations.AddAiFieldsToChatConfig do
+  use Ecto.Migration
+
+  def change do
+    alter table(:chat_configs) do
+      add :ask_model, :string
+      add :ask_rate_limit, :integer
+      add :ask_rate_limit_scale_ms, :integer
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- allow chat config to override global settings
- add additional AI fields to chat config
- support new AI options in ask command and UI
- migration for new chat config fields

## Testing
- `mix ci`

------
https://chatgpt.com/codex/tasks/task_e_684d5b1ba6f88328b0f13761717ba828